### PR TITLE
Update bubble-sort and radix-sort solutions

### DIFF
--- a/specs/bubble-sort/bubble-sort.solution.test.js
+++ b/specs/bubble-sort/bubble-sort.solution.test.js
@@ -14,7 +14,7 @@ function bubbleSort(nums) {
   let swapped = false;
   do {
     swapped = false;
-    for (let i = 0; i < nums.length; i++) {
+    for (let i = 0; i < nums.length - 1; i++) {
       // snapshot(nums);
       if (nums[i] > nums[i + 1]) {
         const temp = nums[i];

--- a/specs/radix-sort/radix-sort.solution.test.js
+++ b/specs/radix-sort/radix-sort.solution.test.js
@@ -49,7 +49,7 @@ function radixSort(array) {
 
 // unit tests
 // do not modify the below code
-describe.skip("radix sort", function () {
+describe("radix sort", function () {
   it("should sort correctly", () => {
     const nums = [
       20,
@@ -104,7 +104,7 @@ describe.skip("radix sort", function () {
     const nums = new Array(fill)
       .fill()
       .map(() => Math.floor(Math.random() * 500000));
-    const ans = radixSort(nums);
-    expect(ans).toEqual(nums.sort());
+    const ans = radixSort([...nums]);
+    expect(ans).toEqual(nums.sort((a, b) => a - b));
   });
 });


### PR DESCRIPTION
Hi Brian, brilliant course as always, thanks ♡

## Bubble sort

Changed index to go only to length - 1. It worked to go up to length, but only implicitly because `10 > undefined === false`
```
    Compare 7 and 8
    Compare 8 and 9
    Compare 9 and 10
    Compare 10 and undefined
```

## Radix sort

The second test in solution works, but only because the input array and the expected output are in fact references to the same array. `array.sort()` actually performs string-based alphabetic sorting, so this is not what we would want (even though the algorithm is correct).

```
[1, 10, 100, 1001, 11, 22, 2].sort()
// [1, 10, 100, 1001, 11, 2, 22]
```