### PR TITLE
Fix bug in radix sort test case

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "algorithms-exercises",
+  "name": "fix-radix-sort-test",
   "version": "1.0.0",
-  "description": "The exercises for the Complete Intro to Algorithms",
+  "description": "",
   "main": "index.html",
   "scripts": {
     "start": "parcel index.html",
@@ -23,5 +23,6 @@
   },
   "resolutions": {
     "@babel/preset-env": "7.13.8"
-  }
+  },
+  "keywords": []
 }

--- a/specs/radix-sort/radix-sort.test.js
+++ b/specs/radix-sort/radix-sort.test.js
@@ -71,6 +71,11 @@ describe.skip("radix sort", function () {
       .fill()
       .map(() => Math.floor(Math.random() * 500000));
     const ans = radixSort(nums);
-    expect(ans).toEqual(nums.sort());
+    expect(ans).toEqual(
+      nums.sort((a, b) => {
+        if (a < b) return -1;
+        return 1;
+      })
+    );
   });
 });


### PR DESCRIPTION
The second test fails if the radix sort algorithm is implemented correctly, because it uses Array.prototype.sort(), the default behavior of which is to treat input as strings. A compare function must be supplied to sort numbers correctly.