### PR TITLE
Missing compare function in test

### DIFF
--- a/specs/radix-sort/radix-sort.test.js
+++ b/specs/radix-sort/radix-sort.test.js
@@ -71,6 +71,6 @@ describe.skip("radix sort", function () {
       .fill()
       .map(() => Math.floor(Math.random() * 500000));
     const ans = radixSort(nums);
-    expect(ans).toEqual(nums.sort());
+    expect(ans).toEqual(nums.sort((a,b) => a - b));
   });
 });


### PR DESCRIPTION
According to MDN docs on [Array.prototype.sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
>The default sort order is ascending, built upon converting the elements into strings
```javascript
[100,2].sort()
// [100, 2]
```

So we would need the compare function to sort numbers properly

```javascript
[100,2].sort((a,b) => a - b)
// [2, 100]
```