### PR TITLE
Fix call to sort function from javascript

### DIFF
--- a/specs/radix-sort/radix-sort.test.js
+++ b/specs/radix-sort/radix-sort.test.js
@@ -71,6 +71,6 @@ describe.skip("radix sort", function () {
       .fill()
       .map(() => Math.floor(Math.random() * 500000));
     const ans = radixSort(nums);
-    expect(ans).toEqual(nums.sort());
+    expect(ans).toEqual(nums.sort((a, b) => a - b));
   });
 });


### PR DESCRIPTION
by default if not passed a comparator function the sort function will sort items as string https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort. So giving the number comparator function here so it sorts correctly.