### PR TITLE
add sort condition to random radix sort test

### DIFF
--- a/specs/radix-sort/radix-sort.test.js
+++ b/specs/radix-sort/radix-sort.test.js
@@ -71,6 +71,6 @@ describe.skip("radix sort", function () {
       .fill()
       .map(() => Math.floor(Math.random() * 500000));
     const ans = radixSort(nums);
-    expect(ans).toEqual(nums.sort());
+    expect(ans).toEqual(nums.sort((a, b) => a - b ));
   });
 });


### PR DESCRIPTION
Add sort condition to prevent numbers being compared alphabetically. This prevented the test to pass with a valid radix sort implementation.