### PR TITLE
Pass comparison callback to sort radix-sort.test.js

### DIFF
--- a/specs/radix-sort/radix-sort.test.js
+++ b/specs/radix-sort/radix-sort.test.js
@@ -71,6 +71,6 @@ describe.skip("radix sort", function () {
       .fill()
       .map(() => Math.floor(Math.random() * 500000));
     const ans = radixSort(nums);
-    expect(ans).toEqual(nums.sort());
+    expect(ans).toEqual(nums.sort((a,b) => a-b));
   });
 });


### PR DESCRIPTION
**unit tests bug**
unit tests rely on `Array.sort` . However, there is no comparison function which will sort the array as they were strings. 

Not sure why tests passed in the case of the solution file. Sandbox is not very good for debugging but test should also fail in there bc of the bug in the test not the algo