### PR TITLE
fix: radix sort test to use spread operator and correct js syntax

### DIFF
--- a/specs/radix-sort/radix-sort.solution.test.js
+++ b/specs/radix-sort/radix-sort.solution.test.js
@@ -104,7 +104,7 @@ describe("radix sort", function () {
     const nums = new Array(fill)
       .fill()
       .map(() => Math.floor(Math.random() * 500000));
-    const ans = radixSort(nums);
-    expect(ans).toEqual(nums.sort());
+    const ans = radixSort([...nums]);
+    expect(ans).toEqual([...nums].sort((a, b) => a - b));
   });
 });

--- a/specs/radix-sort/radix-sort.test.js
+++ b/specs/radix-sort/radix-sort.test.js
@@ -70,7 +70,7 @@ describe.skip("radix sort", function () {
     const nums = new Array(fill)
       .fill()
       .map(() => Math.floor(Math.random() * 500000));
-    const ans = radixSort(nums);
-    expect(ans).toEqual(nums.sort());
+    const ans = radixSort([...nums]);
+    expect(ans).toEqual([...nums].sort((a, b) => a - b));
   });
 });


### PR DESCRIPTION
In the second test case for radix sort there were two bugs
1. It uses incorrect JS Syntax for sorting
2. nums.sort() was sorting same reference array, which method radixSort() did, hence test case was passing everytime, not matter what is returned from radixSort() method in the same array reference.